### PR TITLE
fix: dotenv -> dotenvy

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           path: |
             ~/.cargo/bin/sqlx
-            ~/.cargo/bing/cargo-sqlx
+            ~/.cargo/bin/cargo-sqlx
           key: ${{ runner.os }}-sqlx-${{ env.SQLX_VERSION }}
 
       - name: Install sqlx-cli

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,7 +209,7 @@ dependencies = [
  "chrono",
  "claims",
  "config",
- "dotenv",
+ "dotenvy",
  "fake",
  "hex",
  "hmac",
@@ -761,12 +761,6 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
-
-[[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dotenvy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ hex = "0.4.3"
 htmlescape = "0.3.1"
 actix-web-flash-messages = { version = "0.4.2", features = ["cookies"] }
 shellexpand = "3.0.0"
-dotenv = "0.15.0"
+dotenvy = "0.15.6"
 
 [dev-dependencies]
 reqwest = { version = "0.11.13", default-features = false, features = ["json", "rustls-tls", "cookies"] }

--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -30,7 +30,7 @@ impl Settings {
 
         let environment = Environment::get_env();
         if environment == Environment::Local {
-            dotenv::dotenv().expect(".env not found");
+            dotenvy::dotenv().expect(".env not found");
         }
         let base_config_file = Self::base_config_file(&config_directory);
         let env_specific_config_file = Self::environment_specific_config_file(


### PR DESCRIPTION
the dotenv crate is unmaintained, dotenvy is a well maintained fork.

closes #21 